### PR TITLE
Preserve the line breaks

### DIFF
--- a/modules/blob.bicep
+++ b/modules/blob.bicep
@@ -37,6 +37,6 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
         value: loadTextContent('../data/blob.txt')
       }
     ]
-    scriptContent: 'echo $CONTENT > ${filename} && az storage blob upload -f ${filename} -c ${containerName} -n ${filename}'
+    scriptContent: 'echo "$CONTENT" > ${filename} && az storage blob upload -f ${filename} -c ${containerName} -n ${filename}'
   }
 }

--- a/modules/file.bicep
+++ b/modules/file.bicep
@@ -37,6 +37,6 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
         value: loadTextContent('../data/file.txt')
       }
     ]
-    scriptContent: 'echo $CONTENT > ${filename} && az storage file upload --source ${filename} -s ${fileShareName}'
+    scriptContent: 'echo "$CONTENT" > ${filename} && az storage file upload --source ${filename} -s ${fileShareName}'
   }
 }


### PR DESCRIPTION
With echo "$CONTENT"  the line breaks are preserved. It is important for script files.
Source [StackOverflow](https://stackoverflow.com/questions/22101778/how-to-preserve-line-breaks-when-storing-command-output-to-a-variable)